### PR TITLE
ActiveAdminVersioning.configure

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,37 @@ And then execute:
 
     $ bundle
 
+## Configuration
+
+In some cases you may need to display some extra or formatted text in whodunnit.
+For example whodunit is an ID of your user. And you want to display not just a number, but his E-mail.
+
+Create configuration 'config/initializers/active_admin_versionings.rb'
+
+```ruby
+ActiveAdminVersioning.configure do |config|
+  config.whodunnit_attribute_name = :display_whodunnit
+end
+```
+
+
+In you model:
+
+```ruby
+has_paper_trail class_name: 'MyPaperTrail'
+```
+
+```ruby
+class MyPaperTrail < PaperTrail::Version
+  def display_whodunnit
+    AdminUser.find(whodunnit).email
+  end
+end
+```
+
+This alternative "whodunnit" will only be visible in "Version" sidebar and "Version" page.
+
+
 ## Recipe for Rails 5
 
 1. Add necessary gems to `Gemfile` and `bundle`:

--- a/app/views/application/versions.html.arb
+++ b/app/views/application/versions.html.arb
@@ -2,7 +2,7 @@ paginated_collection(versions, display_total: false, download_links: false) do
   table_for(versions, i18n: ::PaperTrail::Version, class: "index_table") do
     column(:id)
     column(:whodunnit) do |record|
-      record.whodunnit.presence || t("views.version.unknown_user")
+      record.send(ActiveAdminVersioning.configuration.whodunnit_attribute_name).presence || t("views.version.unknown_user")
     end
     column(:event, :event_i18n)
     column(:item_type, :item_class_i18n)

--- a/lib/active_admin_versioning.rb
+++ b/lib/active_admin_versioning.rb
@@ -1,6 +1,7 @@
 require "active_admin"
 require "paper_trail/version_concern"
 require "active_admin_versioning/engine"
+require "active_admin_versioning/configuration"
 require "active_admin_versioning/active_admin/application"
 require "active_admin_versioning/active_admin/dsl"
 require "active_admin_versioning/active_admin/resource_controller"

--- a/lib/active_admin_versioning/active_admin/dsl.rb
+++ b/lib/active_admin_versioning/active_admin/dsl.rb
@@ -27,7 +27,8 @@ module ActiveAdminVersioning
                 end
                 row :event, &:event_i18n
                 row :whodunnit do |record|
-                  record.whodunnit.presence || span(t("views.version.unknown_user"), class: "empty")
+                  record.send(ActiveAdminVersioning.configuration.whodunnit_attribute_name).presence ||
+                      span(t("views.version.unknown_user"), class: "empty")
                 end
                 row :created_at
               end

--- a/lib/active_admin_versioning/configuration.rb
+++ b/lib/active_admin_versioning/configuration.rb
@@ -1,0 +1,22 @@
+module ActiveAdminVersioning
+  class << self
+    attr_writer :configuration
+
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    def configure
+      yield(configuration)
+    end
+  end
+
+
+  class Configuration
+    attr_accessor :whodunnit_attribute_name
+
+    def initialize
+      @whodunnit_attribute_name = :whodunnit
+    end
+  end
+end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "support/with_initializer"
 
 describe "integration test", type: :feature do
   def random_word
@@ -17,6 +18,9 @@ describe "integration test", type: :feature do
     click_button "Update Post"
   end
 
+  let(:post) { Post.first }
+  let(:current_version) { post.versions.last }
+
   describe "visit page of resource is enabled paper_trail" do
     before do
       visit "/admin/posts/new"
@@ -27,9 +31,6 @@ describe "integration test", type: :feature do
     end
 
     describe "viewable registered content" do
-      let(:post) { Post.first }
-      let(:current_version) { post.versions.last }
-
       it "should have elements are registered by dsl" do
         within ".action_items" do
           page.should have_link "Version", href: versions_admin_post_path(1)
@@ -46,8 +47,6 @@ describe "integration test", type: :feature do
     end
 
     describe "viewable versions page" do
-      let(:post) { Post.first }
-
       before { click_link "Version" }
 
       it "should have content" do
@@ -62,4 +61,49 @@ describe "integration test", type: :feature do
       end
     end
   end
+
+
+  describe "when whodunnit_attribute_name is redefined in initializer" do
+    include_context :with_initializer
+
+    before do
+      allow_any_instance_of(PaperTrail::Version)
+          .to receive(whodunnit_attribute_name) { whodunnit_formatted }
+    end
+
+    let(:whodunnit_formatted) do
+      "User: #{current_version.whodunnit}"
+    end
+
+
+    before do
+      visit "/admin/posts/new"
+      create_post
+
+      click_link "Edit Post"
+      update_post
+    end
+
+    describe "sidebar" do
+      it "should display alternative whodunnit" do
+        within "#sidebar" do
+          page.should have_selector "tr.row-whodunnit td", text: whodunnit_formatted, exact: true
+        end
+      end
+    end
+
+    describe "viewable versions page" do
+      before { click_link "Version" }
+
+      it "should display alternative whodunnit" do
+        post.versions.each do |version|
+          within "#paper_trail_version_#{version.id}" do
+            page.should have_selector "td.col-whodunnit", text: whodunnit_formatted, exact: true
+          end
+        end
+      end
+    end
+
+  end
+
 end

--- a/spec/support/with_initializer.rb
+++ b/spec/support/with_initializer.rb
@@ -1,0 +1,20 @@
+shared_context :with_initializer do
+
+  let(:whodunnit_attribute_name) do
+    :display_whodunnit
+  end
+
+  before do
+    ActiveAdminVersioning.configure do |config|
+      config.whodunnit_attribute_name = whodunnit_attribute_name
+    end
+  end
+
+  after :each do
+    # restore defaults
+    ActiveAdminVersioning.configure do |config|
+      config.whodunnit_attribute_name = :whodunnit
+    end
+  end
+
+end


### PR DESCRIPTION
This PR allows to customize how to display "whodunnit" in Sidebar and Version page.
See updated README.md for detail example and explanation.