### PR TITLE
Deprecated 'paper_trail_enabled_for_model?' 

### DIFF
--- a/lib/active_admin_versioning/active_admin/dsl.rb
+++ b/lib/active_admin_versioning/active_admin/dsl.rb
@@ -43,13 +43,11 @@ module ActiveAdminVersioning
       private
 
       def enabled_paper_trail?
-        is_enabled = false
-        if config.resource_class.try(:paper_trail)
-          is_enabled = config.resource_class.try(:paper_trail).try(:enabled?)
+        if config.resource_class.respond_to?(:paper_trail)
+          config.resource_class.paper_trail.try(:enabled?)
         else
-          is_enabled = config.resource_class.try(:paper_trail_enabled_for_model?)
+          config.resource_class.try(:paper_trail_enabled_for_model?)
         end
-        return is_enabled
       end
     end
   end

--- a/lib/active_admin_versioning/active_admin/dsl.rb
+++ b/lib/active_admin_versioning/active_admin/dsl.rb
@@ -43,7 +43,13 @@ module ActiveAdminVersioning
       private
 
       def enabled_paper_trail?
-        config.resource_class.try(:paper_trail).try(:enabled?) || config.resource_class.try(:paper_trail_enabled_for_model?)
+        is_enabled = false
+        if config.resource_class.try(:paper_trail)
+          is_enabled = config.resource_class.try(:paper_trail).try(:enabled?)
+        else
+          is_enabled = config.resource_class.try(:paper_trail_enabled_for_model?)
+        end
+        return is_enabled
       end
     end
   end


### PR DESCRIPTION
I found that the current `if` testing for whether paper_trail was enabled for a model led to my console still spewing a lot of deprecation notices if a model did not have paper trail enabled. This refactors that enabled-test to only call the deprecated method if the model does not respond to `paper_trail`