### PR TITLE
Add a configuration option to override the user used for whodunnit

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ end
 
 This alternative "whodunnit" will only be visible in "Version" sidebar and "Version" page.
 
+You might also want to change the way the current user is fetched. You can do so using the `user_for_paper_trail` configuration.
+
+```ruby
+ActiveAdminVersioning.configure do |config|
+  config.user_for_paper_trail = :current_admin_user
+end
+```
+
 
 ## Recipe for Rails 5
 
@@ -63,6 +71,12 @@ This alternative "whodunnit" will only be visible in "Version" sidebar and "Vers
   $ bin/rails generate active_admin:install
   $ bin/rails generate paper_trail:install
   $ bin/rails db:create db:migrate db:seed
+  ```
+
+  Optionally you can also install the default configuration file:
+
+  ```sh
+  $ bin/rails generate active_admin_versioning:install
   ```
 
 3. Add module of Paper Trail to `AdminUser`:

--- a/lib/active_admin_versioning/active_admin/resource_controller.rb
+++ b/lib/active_admin_versioning/active_admin/resource_controller.rb
@@ -18,6 +18,10 @@ module ActiveAdminVersioning
       protected
 
       def user_for_paper_trail
+        ActiveAdminVersioning.configuration.user_for_paper_trail ? self.send(ActiveAdminVersioning.configuration.user_for_paper_trail) : super
+      end
+
+      def admin_user_for_paper_trail
         respond_to?(:current_admin_user) ? current_admin_user.id : t("views.version.unknown_user")
       end
     end

--- a/lib/active_admin_versioning/configuration.rb
+++ b/lib/active_admin_versioning/configuration.rb
@@ -13,10 +13,11 @@ module ActiveAdminVersioning
 
 
   class Configuration
-    attr_accessor :whodunnit_attribute_name
+    attr_accessor :whodunnit_attribute_name, :user_for_paper_trail
 
     def initialize
       @whodunnit_attribute_name = :whodunnit
+      @user_for_paper_trail     = :admin_user_for_paper_trail
     end
   end
 end

--- a/lib/generators/active_admin_versioning/install/USAGE
+++ b/lib/generators/active_admin_versioning/install/USAGE
@@ -1,0 +1,5 @@
+Description:
+  Creates an initializer for active_admin_versioning.
+
+Example:
+  `rails generate active_admin_versioning:install`

--- a/lib/generators/active_admin_versioning/install/install_generator.rb
+++ b/lib/generators/active_admin_versioning/install/install_generator.rb
@@ -1,0 +1,10 @@
+module ActiveAdminVersioning
+  class InstallGenerator < Rails::Generators::Base
+    source_root File.expand_path('../templates', __FILE__)
+
+    def copy_files
+      template "active_admin_versioning.rb", File.join("config", "initializers", "active_admin_versioning.rb")
+    end
+
+  end
+end

--- a/lib/generators/active_admin_versioning/install/templates/active_admin_versioning.rb
+++ b/lib/generators/active_admin_versioning/install/templates/active_admin_versioning.rb
@@ -1,0 +1,24 @@
+#
+# ActiveAdminVersioning Configuration
+#
+ActiveAdminVersioning.configure do |config|
+  # In some cases you may need to display some extra or formatted text in whodunnit.
+  # For example whodunit is an ID of your user. And you want to display not just a number, but his E-mail.
+  #
+  # In you model:
+  #
+  # has_paper_trail class_name: 'MyPaperTrail'
+  #
+  # class MyPaperTrail < PaperTrail::Version
+  #   def display_whodunnit
+  #     AdminUser.find(whodunnit).email
+  #   end
+  # end
+  #
+  # config.whodunnit_attribute_name = :whodunnit
+
+  # You might want to change the way the current user is set.
+  # You can do that using the `user_for_paper_trail` configuration.
+  #
+  # config.user_for_paper_trail = :admin_user_for_paper_trail
+end


### PR DESCRIPTION
This pull requests adds a configuration option to set which method is used for fetching the current user. Also modified documentation to reflect changes and created an install generator to make it easier to create the initialiser.

Sorry I didn't make any tests, didn't have time for it ... 

Peace ;)