### PR TITLE
Customized namespace

### DIFF
--- a/lib/active_admin_versioning/active_admin/dsl.rb
+++ b/lib/active_admin_versioning/active_admin/dsl.rb
@@ -4,6 +4,8 @@ module ActiveAdminVersioning
       def versioning
         return unless enabled_paper_trail?
 
+        active_admin_namespace = config.namespace.name
+
         controller { include ActiveAdminVersioning::ActiveAdmin::ResourceController }
 
         member_action(:versions) do
@@ -14,7 +16,7 @@ module ActiveAdminVersioning
 
         with_options only: :show do
           action_item :version do
-            link_to send("versions_admin_#{resource_instance_name}_path") do
+            link_to [:versions, active_admin_namespace, resource_instance_name] do
               ::PaperTrail::Version.model_name.human
             end
           end


### PR DESCRIPTION
We can change namespace on active_admin:

```ruby
  # == Default Namespace
  #
  # Set the default namespace each administration resource
  # will be added to.
  #
  # eg:
  #  config.default_namespace = :hello_world
  #
  # This will create resources in the HelloWorld module and
  # will namespace routes to /hello_world/*
  #
  # To set no namespace by default, use:
  #   config.default_namespace = false
  #
  # Default:
  # config.default_namespace = :admin
  #
  # You can customize the settings for each namespace by using
  # a namespace block. For example, to change the site title
  # within a namespace:
  #
  #   config.namespace :admin do |admin|
  #     admin.site_title = "Custom Admin Title"
  #   end
  #
  # This will ONLY change the title for the admin section. Other
  # namespaces will continue to use the main "site_title" configuration.
```

But active_admin_versioning doesn't support customized namespace, so I've fixed this problem.